### PR TITLE
packer min_packer_version crash

### DIFF
--- a/packer-template.json
+++ b/packer-template.json
@@ -1,5 +1,4 @@
 {
-    "min_packer_version": "0.7.2",
     "post-processors": [
         "vagrant"
     ],

--- a/packer-template.json
+++ b/packer-template.json
@@ -41,8 +41,8 @@
     "variables": {
         "username": "vagrant",
         "password": "vagrant",
-        "install_vagrant_keys": true,
-        "update_system": true,
+        "install_vagrant_keys": "true",
+        "update_system": "true",
         "chef_version": "latest",
         "puppet_version": "latest",
         "facter_version": "latest",

--- a/vfuse
+++ b/vfuse
@@ -266,7 +266,9 @@ def generic_packer_template():
                 'shutdown_command': 'sudo shutdown -h now'
             }
         ],
-        'min_packer_version': '0.7.2',
+        # including this key crashes packer 0.8.1
+        # https://github.com/mitchellh/packer/issues/2385
+        # 'min_packer_version': '0.7.2',
         'post-processors': ['vagrant']
     }
     return OrderedDict(d)


### PR DESCRIPTION
I removed the included packer-template.json from vfuse's git repo allowing vfuse to create a new generic template via `generic_packer_template()` in an attempt to resolve [Issue 16](https://github.com/chilcote/vfuse/issues/16) then it crashed.

This is a known issue in packer 0.8.1.

[Adding "min_packer_version" to packer template crashes 0.8.1 #2385](https://github.com/mitchellh/packer/issues/2385)

I propose the workaround of not including min_packer_version in vfuse until 0.8.2 is released.