### PR TITLE
Handle missing keys in templates

### DIFF
--- a/vfuse
+++ b/vfuse
@@ -443,17 +443,22 @@ def main():
                                                 dmg_name, cache_dir)
         output_dir = os.path.expanduser(d['output']) if d['output'] else os.getcwd()
         output_name = d['name']
-        hw_version = d['hw_version'] if isinstance(d['hw_version'], 
-                                                    int) else int(12)
-        mem_size = d['mem_size'] if isinstance(d['mem_size'],
-                                                    int) else int(2048)
-        disk_type = d['disk_type'] if isinstance(d['disk_type'],
-                                                    int) else int(0)
-        packer_template = d['packer_template']
-        connection_type = 'bridged' if d['bridged'] == True else 'nat'
-        enable3d = 'TRUE' if d['enable3d'] == True else 'FALSE'
-        vnc_port = int(d['vnc_port']) if d['vnc_port'] else int(5901)
-        vnc_passwd = d['vnc_passwd'] if d['vnc_passwd'] else None
+        if 'hw_version' in d:
+            hw_version = int(d['hw_version'])
+        if 'mem_size' in d:
+            mem_size = int(d['mem_size'])
+        if 'disk_type' in d: 
+            disk_type = int(d['disk_type'])
+        if 'packer_template' in d:
+            packer_template = d['packer_template']
+        if 'bridged' in d:
+            connection_type = 'bridged' if d['bridged'] == True else 'nat'
+        if 'enable3d' in d:
+            enable3d = 'TRUE' if d['enable3d'] == True else 'FALSE'
+        if 'vnc_port' in d:
+            vnc_port = int(d['vnc_port'])
+        if 'vnc_passwd' in d:
+            vnc_passwd = d['vnc_passwd']
 
     mount_point, disk_id = mount_dmg(source_dmg)
 

--- a/vfuse
+++ b/vfuse
@@ -444,7 +444,7 @@ def main():
         output_dir = os.path.expanduser(d['output']) if d['output'] else os.getcwd()
         output_name = d['name']
 
-        # IF keys exist in the template, use those values.  Otherwise the
+        # If keys exist in the template, use those values.  Otherwise the
         # defaults will be used
         if 'hw_version' in d:
             hw_version = int(d['hw_version'])

--- a/vfuse
+++ b/vfuse
@@ -443,6 +443,9 @@ def main():
                                                 dmg_name, cache_dir)
         output_dir = os.path.expanduser(d['output']) if d['output'] else os.getcwd()
         output_name = d['name']
+
+        # IF keys exist in the template, use those values.  Otherwise the
+        # defaults will be used
         if 'hw_version' in d:
             hw_version = int(d['hw_version'])
         if 'mem_size' in d:

--- a/vfuse
+++ b/vfuse
@@ -445,7 +445,7 @@ def main():
         output_name = d['name']
 
         # If keys exist in the template, use those values.  Otherwise the
-        # defaults will be used
+        # defaults defined earlier will be used
         if 'hw_version' in d:
             hw_version = int(d['hw_version'])
         if 'mem_size' in d:


### PR DESCRIPTION
I discovered when trying to use an older template file with the current vfuse code that if keys are missing from the template vfuse errors.  This pull request fixes this.