### PR TITLE
Handle 'darwinPre15.iso' for pre-10.11 Packer templates

### DIFF
--- a/packer-scripts/vmware-tools.sh
+++ b/packer-scripts/vmware-tools.sh
@@ -3,7 +3,10 @@
 # fork of Tim Sutton's osx-vm-template script:
 # https://github.com/timsutton/osx-vm-templates/blob/master/scripts/vmware.sh
 
-TOOLS_PATH="/Users/$USERNAME/darwin.iso"
+# Globbing here: VMware Fusion >= 8.5.4 includes a second
+# 'darwinPre15.iso' for any OS X guests pre-10.11
+TOOLS_PATH=$(find "/Users/$USERNAME/" -name '*darwin*.iso' -print)
+
 # VMware Fusion specific items
 if [ -e .vmfusion_version ] || [[ "$PACKER_BUILDER_TYPE" == vmware* ]]; then
     if [ ! -e "$TOOLS_PATH" ]; then

--- a/pkgroot/usr/local/vfuse/vfuse
+++ b/pkgroot/usr/local/vfuse/vfuse
@@ -390,7 +390,7 @@ def generic_packer_template():
     }
     return OrderedDict(d)
 
-def populate_packer_template(path, template):
+def populate_packer_template(path, template, os_rev):
     '''Creates a packer template file'''
     if not os.path.exists(template):
         print colored('File not found; creating generic one: %s' % template,
@@ -400,6 +400,10 @@ def populate_packer_template(path, template):
         with open(template, 'r') as f:
             d = json.load(f, object_pairs_hook=OrderedDict)
     d['builders'][0]['source_path'] = path
+    # handle alternate darwin iso used as of VMware Fusion 8.5.4, for
+    # pre-10.11 guests
+    if os_rev < 11:
+        d['builders'][0]['tools_upload_flavor'] = 'darwinPre15'
     with open(template, 'w') as f:
         json.dump(d, f, indent=4, separators=(',', ': '))
     set_perms(template)
@@ -734,7 +738,7 @@ def main():
 
     if packer_template:
         print colored('Generating packer template: %s' % packer_template, 'green')
-        populate_packer_template(vmpath, packer_template)
+        populate_packer_template(vmpath, packer_template, os_rev)
 
     if monitor_vm:
         monitor.set_start(str(vmx), str(job_id))


### PR DESCRIPTION
This updates the packer template generation function to also add the appropriate `tools_upload_flavor`, as 8.5.4 and up now seem to include two different darwin guest tools. `darwin.iso` is only for 10.11 and up.