### PR TITLE
Set reflectHost to false when specifying serial or hw-model.

### DIFF
--- a/pkgroot/usr/local/vfuse/vfuse
+++ b/pkgroot/usr/local/vfuse/vfuse
@@ -350,8 +350,11 @@ def create_vmx(
             f.write('\nethernet0.addressType = "generated"')
         if hw_model:
             f.write('\nhw.model = "%s"' % hw_model)
+            f.write('\nhw.model.reflectHost = "FALSE"')
+            f.write('\nsmbios.reflectHost = "FALSE"')
         if serial_number:
             f.write('\nserialNumber = "%s"' % serial_number)
+            f.write('\nserialNumber.reflectHost = "FALSE"')
         if serial_format:
             f.write('\nSMBIOS.use12CharSerialNumber = "TRUE"')
         if shared_folder:


### PR DESCRIPTION
I had some issues testing DEP where it'd fail if I rolled back to a snapshot, but setting reflectHost helped. See also: [MacAdmins.org Podcast ep 28](http://podcast.macadmins.org/2017/03/20/episode-28-canadian-conferences-dep-installapplication-great-mdm-options/).