### PR TITLE
feat: Add version argument

### DIFF
--- a/pkgroot/usr/local/vfuse/vfuse
+++ b/pkgroot/usr/local/vfuse/vfuse
@@ -536,7 +536,14 @@ def main():
     parser.add_argument('--recovery',
                         help='Boot into Recovery HD',
                         action='store_true')
+    parser.add_argument('--version',
+                        help='Print version of vfuse and exit',
+                        action='store_true')
     args = parser.parse_args()
+
+    if args.version:
+        print __version__
+        sys.exit(0)
 
     if (os.getuid() != 0
             and not args.stop


### PR DESCRIPTION
Make it easy to find out what version of vfuse is currently installed without having to read the script like an animal or sub out to `pkgutil`.