### PR TITLE
Add ability to configure qemu-img path

### DIFF
--- a/pkgroot/usr/local/vfuse/bin/vfuse
+++ b/pkgroot/usr/local/vfuse/bin/vfuse
@@ -687,8 +687,11 @@ def main():
     parser.add_argument('--stop', help='Stop monitoring of VM')
     parser.add_argument('--reset', help='Reset monitored VM')
     parser.add_argument('--use-qemu',
-                        help='Use qemu-img intead of the Fusion CLI tools',
-                        action='store_true')
+                        help='Use qemu-img intead of the Fusion CLI tools [/path/to/qemu-img]',
+                        default=False,
+                        const='/usr/local/bin/qemu-img',
+                        nargs='?',
+                        action='store')
     parser.add_argument('--recovery',
                         help='Boot into Recovery HD',
                         action='store_true')
@@ -898,6 +901,8 @@ def main():
 
     if args.use_qemu:
         use_qemu = True
+        if os.path.exists(args.use_qemu):
+            qemu_path = args.use_qemu
 
     if args.recovery:
         recovery = True


### PR DESCRIPTION
`qemu-img` path  in `vfuse` is hardcored to `/usr/local/bin/qemu-img`.
I wanted to use different path (MacPort `/opt/local/bin/qemu-img`)).
This patch enables to provide configure it via parametr.

1. `--qemu-img` (defaults to `/usr/local/bin/qemu-img`)
2. `--qemu-img /path/to/qemu-img` (use `/path/to/qemu-img` if valid os.path else use default)

Code could probably enhanced. Default `qemu_path` is now specified in two places.