### PR TITLE
For the APFS disk image, use the unmount instead of the enject.

### DIFF
--- a/pkgroot/usr/local/vfuse/bin/vfuse
+++ b/pkgroot/usr/local/vfuse/bin/vfuse
@@ -325,6 +325,18 @@ def unmount_dmg(pathname):
         if err:
             print(colored("Could not detach:\t%s" % pathname, "yellow"))
 
+def unmount_vols(disk_id):
+    """Unmount all volumes at the disk_id"""
+    print(colored("Unmounting %s" % disk_id, "green"))
+    task = subprocess.Popen(
+        ["/usr/sbin/diskutil", "unmountDisk", disk_id],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = task.communicate()
+    if err:
+        print(colored("Could not unmount:\t%s" % disk_id, "yellow"))
+
 
 def create_vmdk(
     output_dir,
@@ -1078,7 +1090,7 @@ def main():
     guest_os = "darwin%d-64" % (os_rev + 4)
 
     if volume_kind == "apfs":
-        unmount_dmg(mount_point)
+        unmount_vols(disk_id)
 
     vmpath, fusion_tools_path = create_vmdk(
         output_dir,


### PR DESCRIPTION
The hdiutil enject will enject all of the mounted disk image contents. This would lead the vmware-vdiskmanager failed to operate on the disk /dev/diskX. The `diskutil unmountDisk ` will only unmount the disk volumes but kept the disk image opened on the current macOS.


Testing:
1. On macOS 10.15,
% ~/Documents/GitHub/vfuse/pkgroot/usr/local/vfuse/bin/vfuse --use-qemu -i ~/Desktop/vFuse-vdiskmanager/osx-10.15-19A583.apfs.dmg -o /Volumes/Shared/vFuse/On1015_use_qemu
Mounting /Users/zhaokaiy/Desktop/vFuse-vdiskmanager/osx-10.15-19A583.apfs.dmg
macOS version is 10.15
Unmounting /dev/disk2
Using qemu-img path: /usr/local/bin/qemu-img
Converting DMG to VMDK
Populating VMX file
Unmounting /dev/disk2
VMware Fusion VM created at /Volumes/Shared/vFuse/On1015_use_qemu/macos-vm.vmwarevm

2. On macOS 10.15,
% ~/Documents/GitHub/vfuse/pkgroot/usr/local/vfuse/bin/vfuse -i ~/Desktop/vFuse-vdiskmanager/osx-10.15-19A583.apfs.dmg -o /Volumes/Shared/vFuse/On1015

If you don't want to be prompted in the GUI for an admin password, run this script with sudo rights

Mounting /Users/zhaokaiy/Desktop/vFuse-vdiskmanager/osx-10.15-19A583.apfs.dmg
macOS version is 10.15
Unmounting /dev/disk2
Using VMware Fusion path: /Applications/VMware Fusion.app
Converting DMG to VMDK
Hiding file extension
Populating VMX file
Unmounting /dev/disk2
VMware Fusion VM created at /Volumes/Shared/vFuse/On1015/macos-vm.vmwarevm


3. On macOS 10.14
%  /Volumes/Shared/vFuse/vfuse/pkgroot/usr/local/vfuse/bin/vfuse -i ./osx-10.14.5-18F132.apfs.dmg -o ./

Verified that the macos-vm.vmwarevm could be powered on and used successfully.
